### PR TITLE
Support Windows Unicode

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ Basic use:
 
     #include "cfgpath.h"
     
-    char cfgdir[MAX_PATH];
-    get_user_config_file(cfgdir, sizeof(cfgdir), "myapp");
+    cfgpathchar_t cfgdir[MAX_PATH];
+    get_user_config_file(cfgdir, sizeof(cfgdir)/sizeof(cfgdir[0]), CFGPATHTEXT("myapp"));
     if (cfgdir[0] == 0) {
         printf("Unable to find home directory.\n");
         return 1;
     }
-    printf("Saving configuration file to %s\n", cfgdir);
+    cfgpath__printf(CFGPATHTEXT("Saving configuration file to %s\n"), cfgdir);
 
 To integrate it into your own project, just copy cfgpath.h.  All the other
 files are for testing to make sure it works correctly, so you don't need them

--- a/test-linux.c
+++ b/test-linux.c
@@ -40,12 +40,15 @@ char *test_getenv(const char *var)
 int test_mkdir(const char *path, mode_t mode)
 {
 	return 0;
+	// silence unused variable warnings
+	(void)path;
+	(void)mode;
 }
 
 #define TOSTRING_X(x) #x
 #define TOSTRING(x) TOSTRING_X(x)
 #define RUN_TEST(result, msg)	  \
-	TEST_FUNC(buffer, sizeof(buffer), "test-linux"); \
+	TEST_FUNC(buffer, sizeof(buffer)/sizeof(buffer[0]), "test-linux"); \
 	CHECK_RESULT(result, msg)
 
 #define CHECK_RESULT(result, msg) \
@@ -57,9 +60,9 @@ int test_mkdir(const char *path, mode_t mode)
 		printf("PASS: " TOSTRING(TEST_FUNC) "() " msg "\n"); \
 	}
 
-int main(int argc, char *argv[])
+int main(void)
 {
-	char buffer[256];
+	cfgpathchar_t buffer[MAX_PATH];
 
 /*
  * get_user_config_file()

--- a/test-win-unicode.c
+++ b/test-win-unicode.c
@@ -1,0 +1,105 @@
+/**
+ * @file  test-win-unicode.c
+ * @brief cfgpath.h test code for the Windows, with Unicode support.
+ *
+ * Copyright (C) 2013 Adam Nielsen <malvineous@shikadi.net>
+ *
+ * This code is placed in the public domain.  You are free to use it for any
+ * purpose.  If you add new platform support, please contribute a patch!
+ */
+
+#include <string.h>
+#include <stdio.h>
+
+#define SHGetFolderPath test_SHGetFolderPath
+#define mkdir test_mkdir
+int test_mkdir(void *path);
+int test_SHGetFolderPath(void *hwndOwner, int nFolder, void *hToken, int dwFlags, void *_pszPath);
+#undef __linux__
+#ifndef WIN32
+#define WIN32
+#endif
+#ifndef UNICODE // enable unicode before #include-ing cfgpath.h
+#define UNICODE
+#endif
+#include "cfgpath.h"
+
+const cfgpathchar_t *set_appdata;
+const cfgpathchar_t *set_appdata_local;
+int set_retval;
+
+/* Fake implementation of SHGetFolderPath() that fails when and how we want */
+int test_SHGetFolderPath(void *hwndOwner, int nFolder, void *hToken,
+	int dwFlags, void *_pszPath)
+{
+    // silence unused variable warnings
+    (void)hwndOwner;
+    (void)hToken;
+    (void)dwFlags;
+
+	/* Hopefully trigger an error if the buffer is too small */
+    cfgpathchar_t *pszPath = (cfgpathchar_t*) _pszPath;
+	pszPath[MAX_PATH - 1] = 0;
+
+	switch (nFolder) {
+		case CSIDL_APPDATA:
+			if (set_appdata) {
+				cfgpath__strcpy(pszPath, set_appdata);
+				return set_retval;
+			}
+			break;
+		case CSIDL_LOCAL_APPDATA:
+			if (set_appdata_local) {
+				cfgpath__strcpy(pszPath, set_appdata_local);
+				return set_retval;
+			}
+			break;
+	}
+	return E_FAIL;
+}
+
+int test_mkdir(void *path)
+{
+	return 0;
+    (void)path; // silence unused variable warning
+}
+
+int main(void)
+{
+	cfgpathchar_t buffer[MAX_PATH];
+
+// get_user_config_file
+    get_user_config_file(buffer, sizeof(buffer)/sizeof(buffer[0]), CFGPATHTEXT("myapp"));
+    if (buffer[0] == 0) {
+        printf("get_user_config_file() fail\n");
+        return 1;
+    }
+    cfgpath__printf(CFGPATHTEXT("get_user_config_file() returned '%s'!\n"), buffer);
+
+// get_user_config_folder
+    get_user_config_folder(buffer, sizeof(buffer)/sizeof(buffer[0]), CFGPATHTEXT("myapp"));
+    if (buffer[0] == 0) {
+        printf("get_user_config_folder() fail\n");
+        return 1;
+    }
+    cfgpath__printf(CFGPATHTEXT("get_user_config_folder() returned '%s'!\n"), buffer);
+
+// get_user_data_folder
+    get_user_data_folder(buffer, sizeof(buffer)/sizeof(buffer[0]), CFGPATHTEXT("myapp"));
+    if (buffer[0] == 0) {
+        printf("get_user_data_folder() fail\n");
+        return 1;
+    }
+    cfgpath__printf(CFGPATHTEXT("get_user_data_folder() returned '%s'!\n"), buffer);
+
+// get_user_cache_folder
+    get_user_cache_folder(buffer, sizeof(buffer)/sizeof(buffer[0]), CFGPATHTEXT("myapp"));
+    if (buffer[0] == 0) {
+        printf("get_user_cache_folder() fail\n");
+        return 1;
+    }
+    cfgpath__printf(CFGPATHTEXT("get_user_cache_folder() returned '%s'!\n"), buffer);
+
+	printf("All tests passed for platform: Windows (Unicode).\n");
+	return 0;
+}

--- a/test-win.c
+++ b/test-win.c
@@ -1,6 +1,6 @@
 /**
- * @file  test-linux.c
- * @brief cfgpath.h test code for the Linux platform.
+ * @file  test-win.c
+ * @brief cfgpath.h test code for the Windows platform.
  *
  * Copyright (C) 2013 Adam Nielsen <malvineous@shikadi.net>
  *
@@ -13,9 +13,14 @@
 
 #define SHGetFolderPath test_SHGetFolderPath
 #define mkdir test_mkdir
+int test_mkdir(const char *path);
+int test_SHGetFolderPath(void *hwndOwner, int nFolder, void *hToken, int dwFlags, char *pszPath);
 #undef __linux__
 #ifndef WIN32
 #define WIN32
+#endif
+#ifdef UNICODE
+#undef UNICODE // try test-win-unicode.c if you want a unicode example
 #endif
 #include "cfgpath.h"
 
@@ -27,6 +32,11 @@ int set_retval;
 int test_SHGetFolderPath(void *hwndOwner, int nFolder, void *hToken,
 	int dwFlags, char *pszPath)
 {
+    // silence unused variable warnings
+    (void)hwndOwner;
+    (void)hToken;
+    (void)dwFlags;
+
 	/* Hopefully trigger an error if the buffer is too small */
 	pszPath[MAX_PATH - 1] = 0;
 
@@ -50,16 +60,17 @@ int test_SHGetFolderPath(void *hwndOwner, int nFolder, void *hToken,
 int test_mkdir(const char *path)
 {
 	return 0;
+    (void)path; // silence unused variable warning
 }
 
 #define TOSTRING_X(x) #x
 #define TOSTRING(x) TOSTRING_X(x)
 #define RUN_TEST(result, msg)	  \
-	TEST_FUNC(buffer, sizeof(buffer), "test-win"); \
+	TEST_FUNC(buffer, sizeof(buffer)/sizeof(buffer[0]), "test-win"); \
 	CHECK_RESULT(result, msg)
 
 #define CHECK_RESULT(result, msg) \
-	if (strcmp(buffer, result) != 0) { \
+	if (cfgpath__strcmp(buffer, result) != 0) { \
 		printf("FAIL: %s:%d " TOSTRING(TEST_FUNC) "() " msg "  Test failed, " \
 			"returning the wrong value.\n" \
 			"Expected: %s\nGot: %s\n", __FILE__, __LINE__, result, buffer); \
@@ -68,9 +79,9 @@ int test_mkdir(const char *path)
 		printf("PASS: " TOSTRING(TEST_FUNC) "() " msg "\n"); \
 	}
 
-int main(int argc, char *argv[])
+int main(void)
 {
-	char buffer[256];
+	cfgpathchar_t buffer[MAX_PATH];
 
 /*
  * get_user_config_file()


### PR DESCRIPTION
This update introduces a type `cfgpathchar_t` which will be treated as `wchar_t` and use `wchar_t` string functions if the constant `UNICODE` is defined when building for Windows; `char` and the C standard library will be used otherwise.

The macro `CFGPATHTEXT` is also introduced so string constants will be prefixed with `L` when the constant `UNICODE` is defined when building for Windows.

Additionally, the usage examples display `sizeof(buf)/sizeof(buf[0])` being passed in for the `maxlen` arguments because `cfgpathchar_t` is not guaranteed to have a size of 1 (it will be at least 2 if building with `UNICODE` defined on Windows).

Now if a path contains more than just standard ASCII, Windows will still return a usable path. Consider the configuration file path...
`C:\Documents and Settings\Name\Application Data\myapp.ini`
... where `Name` contains characters such as `ò`, `ü`, etc. As long as the user has `#define UNICODE` before `#include "cfgpath.h"`, the propagated `cfgpathchar_t` can be used with `_wfopen`.

I have tested on Windows (both with and without `UNICODE`) and Linux to confirm everything is still working.