### PR TITLE
added compiler check for __MINGW32__, so it includes direct.h.

### DIFF
--- a/cfgpath.h
+++ b/cfgpath.h
@@ -33,7 +33,7 @@
 #ifndef CFGPATH_H_
 #define CFGPATH_H_
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__MINGW32__)
 #define inline __inline
 #include <direct.h>
 #define mkdir _mkdir


### PR DESCRIPTION
I was having issues compiling my application with the mingw compiler, it turns out this compiler needs direct.h along side the Microsoft compiler.