### PR TITLE
Changed the macOS functionning so it is no more deprecated.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 test-linux
 test-win
+test-macos

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all check
+.PHONY: all check clean
 
 all: test-linux test-win test-macos
 
@@ -6,6 +6,9 @@ check: test-linux test-win test-macos
 	./test-linux
 	./test-win
 	./test-macos
+
+clean:
+	rm -f test-linux test-win test-macos
 
 test-linux: test-linux.c cfgpath.h
 	$(CC) -O0 -g -o $@ $<

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,17 @@
 .PHONY: all check
 
-all: test-linux test-win
+all: test-linux test-win test-macos
 
-check: test-linux test-win
+check: test-linux test-win test-macos
 	./test-linux
 	./test-win
+	./test-macos
 
 test-linux: test-linux.c cfgpath.h
 	$(CC) -O0 -g -o $@ $<
 
 test-win: test-win.c cfgpath.h shlobj.h
 	$(CC) -O0 -g -o $@ $< -I.
+
+test-macos: test-macos.c cfgpath.h
+	$(CC) -O0 -g -o $@ $<

--- a/cfgpath.h
+++ b/cfgpath.h
@@ -72,6 +72,10 @@
 #error cfgpath.h functions have not been implemented for your platform!  Please send patches.
 #endif
 
+#ifdef __cplusplus
+namespace cfgpath {
+#endif
+
 static inline void get_user_config_file(char *out, unsigned int maxlen, const char *appname);
 static inline void get_user_config_folder(char *out, unsigned int maxlen, const char *appname);
 static inline void get_user_data_folder(char *out, unsigned int maxlen, const char *appname);
@@ -487,5 +491,9 @@ static inline void get_user_cache_folder(char *out, unsigned int maxlen, const c
 	get_user_config_folder(out, maxlen, appname);
 #endif
 }
+
+#ifdef __cplusplus
+} // namespace cfgpath
+#endif
 
 #endif /* CFGPATH_H_ */

--- a/test-macos.c
+++ b/test-macos.c
@@ -1,0 +1,20 @@
+#include "cfgpath.h"
+
+#include <stdio.h>
+
+int main() {
+    char config_folder[MAX_PATH];
+    char config_file[MAX_PATH];
+    char data_folder[MAX_PATH];
+    char cache_folder[MAX_PATH];
+
+    get_user_config_folder(config_folder, MAX_PATH, "myapp");
+    get_user_config_file(config_file, MAX_PATH, "myapp");
+    get_user_data_folder(data_folder, MAX_PATH, "myapp");
+    get_user_cache_folder(cache_folder, MAX_PATH, "myapp");
+
+    printf("Config folder: %s\n", strlen(config_folder) ? config_folder : "ERROR");
+    printf("Config file:   %s\n", strlen(config_file) ? config_file : "ERROR");
+    printf("Data folder:   %s\n", strlen(data_folder) ? data_folder : "ERROR");
+    printf("Cache folder:  %s\n", strlen(cache_folder) ? cache_folder : "ERROR");
+}

--- a/test-macos.c
+++ b/test-macos.c
@@ -3,18 +3,21 @@
 #include <stdio.h>
 
 int main() {
-    char config_folder[MAX_PATH];
-    char config_file[MAX_PATH];
-    char data_folder[MAX_PATH];
-    char cache_folder[MAX_PATH];
+    char* config_file = malloc(MAX_PATH * sizeof(char));
+    char* config_folder = malloc(MAX_PATH * sizeof(char));
+    char* data_folder = malloc(MAX_PATH * sizeof(char));
+    char* cache_folder = malloc(MAX_PATH * sizeof(char));
+    char* too_small = malloc(10 * sizeof(char));
 
-    get_user_config_folder(config_folder, MAX_PATH, "myapp");
     get_user_config_file(config_file, MAX_PATH, "myapp");
+    get_user_config_folder(config_folder, MAX_PATH, "myapp");
     get_user_data_folder(data_folder, MAX_PATH, "myapp");
     get_user_cache_folder(cache_folder, MAX_PATH, "myapp");
+    get_user_config_folder(too_small, 10, "myapp");
 
-    printf("Config folder: %s\n", strlen(config_folder) ? config_folder : "ERROR");
-    printf("Config file:   %s\n", strlen(config_file) ? config_file : "ERROR");
-    printf("Data folder:   %s\n", strlen(data_folder) ? data_folder : "ERROR");
-    printf("Cache folder:  %s\n", strlen(cache_folder) ? cache_folder : "ERROR");
+    printf("Config file:      %s\n", strlen(config_file) ? config_file : "ERROR");
+    printf("Config folder:    %s\n", strlen(config_folder) ? config_folder : "ERROR");
+    printf("Data folder:      %s\n", strlen(data_folder) ? data_folder : "ERROR");
+    printf("Cache folder:     %s\n", strlen(cache_folder) ? cache_folder : "ERROR");
+    printf("Should be error:  %s\n", strlen(too_small) ? too_small : "ERROR");
 }


### PR DESCRIPTION
I also created basic tests for macOS and a namespace when compiled in C++. On the previous version we needed to link to Cocoa framework to use the `FSFindFolder` and `FSRefMakePath` functions but now the new functions live somewhere else (maybe in libc?)
However while looking in `test-win.c`, I saw that the user name of the paths were always "test-win" and that should lead to a failed test (I did not tested I don't have windows).